### PR TITLE
Inko is active

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -31,8 +31,8 @@
         "name": "Inko",
         "description": "Statically-typed, safe, OO language for writing concurrent programs.",
         "url": "https://inko-lang.org/",
-        "stars": 0,
-        "active": false
+        "stars": 135,
+        "active": true
     },
     {
         "name": "Gluon",


### PR DESCRIPTION
13ee9c2e on Main on 2022-04-22
ffc25ab3 on single-ownership on 2022-06-02

It's hosted on [Gitlab](https://gitlab.com/inko-lang/inko), maybe that's why it was seen as inactive?