### PR TITLE
Add Typst (and fix readme generation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,129 +15,129 @@ Then it can be included in this list!
 
 | Name | ⭐ Stars | ☀️ Status | Description |
 |:-----|:---------|:-----------|:-----------|
-| [Deno] | 88,397 | ☀️ Active | A modern runtime for JavaScript and TypeScript. |
-| [Rust] | 78,830 | ☀️ Active | Empowering everyone to build reliable and efficient software. |
-| [Parcel JavaScript Transformer] | 42,109 | ☀️ Active | The zero configuration build tool for the web. 📦🚀 |
-| [swc] | 26,551 | ☀️ Active | Rust-based platform for the Web |
-| [nu] | 25,568 | ☀️ Active | Scripting language of [nushell](https://github.com/nushell/nushell). The goal of this project is to take the Unix philosophy of shells, where pipes connect simple commands together, and bring it to the modern style of development. Thus, rather than being either a shell, or a programming language, Nushell connects both by bringing a rich programming language and a full-featured shell together into one package. |
+| [Deno] | 91,548 | ☀️ Active | A modern runtime for JavaScript and TypeScript. |
+| [Rust] | 87,702 | ☀️ Active | Empowering everyone to build reliable and efficient software. |
+| [Parcel JavaScript Transformer] | 42,819 | ☀️ Active | The zero configuration build tool for the web. 📦🚀 |
+| [Sway] | 37,683 | ☀️ Active | 🌴 Empowering everyone to build reliable and efficient smart contracts. |
+| [swc] | 29,050 | ☀️ Active | Rust-based platform for the Web |
 | [Typst] | 23,742 | ☀️ Active | A new markup-based typesetting system that is powerful and easy to learn. |
-| [RustPython] | 14,414 | ☀️ Active | A Python Interpreter written in Rust |
-| [Gleam] | 4,720 | ☀️ Active | ⭐️ A friendly language for building type-safe, scalable systems! |
-| [Melody] | 4,072 | ☀️ Active | Melody is a language that compiles to regular expressions and aims to be more easily readable and maintainable |
-| [Boa] | 3,813 | ☀️ Active | Boa is an embeddable and experimental Javascript engine written in Rust. Currently, it has support for some of the language. |
-| [Parcel CSS] | 3,351 | ☀️ Active | An extremely fast CSS parser, transformer, bundler, and minifier written in Rust. |
-| [Kind] | 3,025 | ☀️ Active | A next-gen functional language |
-| [Artichoke] | 2,863 | ☀️ Active | 💎 Artichoke is a Ruby made with Rust |
-| [Gluon] | 2,783 | ☀️ Active | A static, type inferred and embeddable language written in Rust. |
-| [Rhai] | 2,589 | ☀️ Active | Rhai - An embedded scripting language for Rust. |
-| [Jakt] | 2,484 | ☀️ Active | The Jakt Programming Language |
-| [Roc] | 2,263 | ☀️ Active | A fast, friendly, functional language. Work in progress! |
-| [Erg] | 2,130 | ☀️ Active | A statically typed language that can deeply improve the Python ecosystem |
-| [Move] | 1989 | ☀️ Active | A programming language for writing safe and smart contracts in blockchain. |
-| [Scryer Prolog] | 1,655 | ☀️ Active | A modern Prolog implementation written mostly in Rust. |
-| [Ante] | 1,592 | ☀️ Active | A safe, easy systems language |
-| [Dyon] | 1,555 | ☀️ Active | A rusty dynamically typed scripting language |
-| [Mun] | 1,518 | ☀️ Active | Source code for the Mun language and runtime. |
-| [goscript] | 1,421 | ☀️ Active | An alternative implementation of Golang specs, written in Rust for embedding or wrapping. |
-| [Fe] | 1,408 | ☀️ Active | Emerging smart contract language for the Ethereum blockchain. |
-| [Nickel] | 1,314 | ☀️ Active | Better configuration for less |
-| [Differential Datalog] | 1,248 | ☀️ Active | DDlog is a programming language for incremental computation. It is well suited for writing programs that continuously update their output in response to input changes. A DDlog programmer does not write incremental algorithms; instead they specify the desired input-output mapping in a declarative manner. |
-| [Rune] | 1,144 | ☀️ Active | An embeddable dynamic programming language for Rust. |
-| [frawk] | 1,069 | ☀️ Active | an efficient awk-like language |
-| [Tao] | 880 | ☀️ Active | A statically-typed functional language with generics, typeclasses, sum types, pattern-matching, first-class functions, currying, algebraic effects, associated types, good diagnostics, etc. |
-| [CSML] | 660 | ☀️ Active | CSML is an easy-to-use chatbot programming language and framework. |
-| [SPWN] | 627 | ☀️ Active | A language for Geometry Dash triggers |
-| [KCLVM] | 474 | ☀️ Active | A constraint-based record & functional language mainly used in configuration and policy scenarios. |
-| [Wu] | 440 | ☀️ Active | 🐉 A practical game and data language |
-| [Duckscript] | 425 | ☀️ Active | Simple, extendable and embeddable scripting language. |
-| [Leo] | 401 | ☀️ Active | 🦁 The Leo Programming Language. A Programming Language for Formally Verified, Zero-Knowledge Applications |
-| [Sway] | 389 | ☀️ Active | 🌴 Empowering everyone to build reliable and efficient smart contracts. |
-| [Starlark] | 388 | ☀️ Active | A Rust implementation of the Starlark language |
-| [jsparagus] | 372 | ☀️ Active | Experimental JS parser-generator project. |
-| [Koto] | 326 | ☀️ Active | A simple, expressive, embeddable programming language, made with Rust |
-| [EndBASIC] | 232 | ☀️ Active | BASIC environment with a REPL, a web interface, a graphical console, and RPi support written in Rust |
-| [Orion] | 229 | ☀️ Active | Orion is a high level, purely functional programming language with a LISP based syntax. |
-| [Inko] | 217 | ☀️ Active | A language for building concurrent software with confidence. This is a read-only mirror of https://gitlab.com/inko-lang/inko |
-| [Tokay] | 197 | ☀️ Active | Tokay is a programming language designed for ad-hoc parsing, inspired by awk. |
-| [Lurk] | 192 | ☀️ Active | None |
-| [Veryl] | 162 | ☀️ Active | Veryl: A Modern Hardware Description Language |
-| [crafting-interpreters-rs] | 160 | ☀️ Active | Crafting Interpreters in Rust |
-| [TablaM] | 154 | ☀️ Active | The practical relational programming language for data-oriented applications |
-| [Steel] | 121 | ☀️ Active | An embedded scheme interpreter in Rust |
-| [Butter] | 114 | ☀️ Active | A tasty language for building efficient software. Currently work in progress! |
-| [Antimony] | 103 | ☀️ Active | The Antimony programming language |
-| [Boson] | 103 | ☀️ Active | A hybrid programming language written in Rust.  |
-| [Tvix] | 101 | ☀️ Active | An implementation of the Nix language, in Rust. |
-| [Calcit] | 71 | ☀️ Active | Lisp compiling to JavaScript ES Modules |
-| [rtforth] | 65 | ☀️ Active | Forth implemented in Rust for realtime application |
-| [Laythe] | 59 | ☀️ Active | A gradually typed language originally based on the crafting interpreters series  |
-| [Calypso] | 57 | ☀️ Active | Calypso is a mostly imperative language with some functional influences that is focused on flexibility and simplicity. |
-| [Oriel] | 45 | ☀️ Active | An interpreter for the 1991 Oriel scripting language. |
-| [Chili] | 41 | ☀️ Active | General-purpose, compiled programming language, focused on productivity, expressiveness and joy of programming™ |
-| [tox] | 35 | ☀️ Active | Tox is a statically typed version programming language that is written in rust. |
-| [Foolang] | 33 | ☀️ Active | A toy programming language. |
+| [RustPython] | 15,920 | ☀️ Active | A Python Interpreter written in Rust |
+| [Gleam] | 5,580 | ☀️ Active | ⭐️ A friendly language for building type-safe, scalable systems! |
+| [Parcel CSS] | 5,109 | ☀️ Active | An extremely fast CSS parser, transformer, bundler, and minifier written in Rust. |
+| [Melody] | 4,520 | ☀️ Active | Melody is a language that compiles to regular expressions and aims to be more readable and maintainable |
+| [Boa] | 4,345 | ☀️ Active | Boa is an embeddable and experimental Javascript engine written in Rust. Currently, it has support for some of the language. |
+| [Kind] | 3,321 | ☀️ Active | A next-gen functional language |
+| [Leo] | 3,222 | ☀️ Active | 🦁 The Leo Programming Language. A Programming Language for Formally Verified, Zero-Knowledge Applications |
+| [Rhai] | 3,180 | ☀️ Active | Rhai - An embedded scripting language for Rust. |
+| [Gluon] | 3,019 | ☀️ Active | A static, type inferred and embeddable language written in Rust. |
+| [Roc] | 3,003 | ☀️ Active | A fast, friendly, functional language. Work in progress! |
+| [Artichoke] | 2,955 | ☀️ Active | 💎 Artichoke is a Ruby made with Rust |
+| [Jakt] | 2,693 | ☀️ Active | The Jakt Programming Language |
+| [Erg] | 2,369 | ☀️ Active | A statically typed language that can deeply improve the Python ecosystem |
+| [Move] | 2,064 | ☀️ Active | None |
+| [Move] | 2,064 | ☀️ Active | None |
+| [Nickel] | 1,912 | ☀️ Active | Better configuration for less |
+| [Scryer Prolog] | 1,799 | ☀️ Active | A modern Prolog implementation written mostly in Rust. |
+| [Ante] | 1,693 | ☀️ Active | A safe, easy systems language |
+| [Mun] | 1,644 | ☀️ Active | Source code for the Mun language and runtime. |
+| [Dyon] | 1,640 | ☀️ Active | A rusty dynamically typed scripting language |
+| [Fe] | 1,518 | ☀️ Active | Emerging smart contract language for the Ethereum blockchain. |
+| [goscript] | 1,497 | ☀️ Active | An alternative implementation of Golang specs, written in Rust for embedding or wrapping. |
+| [Rune] | 1,387 | ☀️ Active | An embeddable dynamic programming language for Rust. |
+| [Differential Datalog] | 1,293 | ☀️ Active | DDlog is a programming language for incremental computation. It is well suited for writing programs that continuously update their output in response to input changes. A DDlog programmer does not write incremental algorithms; instead they specify the desired input-output mapping in a declarative manner. |
+| [frawk] | 1,144 | ☀️ Active | an efficient awk-like language |
+| [Tao] | 1,030 | ☀️ Active | A statically-typed functional language with generics, typeclasses, sum types, pattern-matching, first-class functions, currying, algebraic effects, associated types, good diagnostics, etc. |
+| [KCLVM] | 948 | ☀️ Active | KCL Language Core. KCL is a constraint-based record & functional language mainly used in configuration and policy scenarios. (CNCF Sandbox Project). https://kcl-lang.io |
+| [SPWN] | 766 | ☀️ Active | A language for Geometry Dash triggers |
+| [Astro] | 712 | ☀️ Active | A fun safe language for rapid prototyping and high performance applications |
+| [CSML] | 692 | ☀️ Active | CSML is an easy-to-use chatbot programming language and framework. |
+| [Inko] | 620 | ☀️ Active | A language for building concurrent software with confidence |
+| [Steel] | 602 | ☀️ Active | An embedded scheme interpreter in Rust |
+| [Starlark] | 537 | ☀️ Active | A Rust implementation of the Starlark language |
+| [Duckscript] | 460 | ☀️ Active | Simple, extendable and embeddable scripting language. |
+| [jsparagus] | 410 | ☀️ Active | Experimental JS parser-generator project. |
+| [Wain] | 374 | ☀️ Active | WebAssembly implementation from scratch in Safe Rust with zero dependencies |
+| [Koto] | 354 | ☀️ Active | A simple, expressive, embeddable programming language, made with Rust |
+| [Lurk] | 348 | ☀️ Active | Lurk is a Turing-complete programming language for recursive zk-SNARKs.  It is a statically scoped dialect of Lisp, influenced by Scheme and Common Lisp. |
+| [EndBASIC] | 288 | ☀️ Active | BASIC environment with a REPL, a web interface, a graphical console, and RPi support written in Rust |
+| [Tokay] | 220 | ☀️ Active | Tokay is a programming language designed for ad-hoc parsing, inspired by awk. |
+| [Veryl] | 216 | ☀️ Active | Veryl: A Modern Hardware Description Language |
+| [Tvix] | 186 | ☀️ Active | Tvix - A Rust implementation of Nix. Read-only mirror of https://cs.tvl.fyi/depot/-/tree/tvix |
+| [Antimony] | 115 | ☀️ Active | The Antimony programming language |
+| [Butter] | 112 | ☀️ Active | A tasty language for building efficient software. Currently work in progress! |
+| [Calcit] | 92 | ☀️ Active | Indentation-based ClojureScript compiling to JavaScript ES Modules |
+| [Darksecond/lox] | 84 | ☀️ Active | A rust implementation of the lox language |
+| [rtforth] | 78 | ☀️ Active | Forth implemented in Rust for realtime application |
+| [Laythe] | 63 | ☀️ Active | A gradually typed language originally based on the crafting interpreters series  |
+| [Calypso] | 60 | ☀️ Active | Calypso is a mostly imperative language with some functional influences that is focused on flexibility and simplicity. |
+| [Oriel] | 55 | ☀️ Active | An interpreter for the 1991 Oriel scripting language |
+| [Stellar] | 40 | ☀️ Active | ✨ An open source WIP general programming language for web development built using Rust. ✨ |
+| [Ellie] | 39 | ☀️ Active | Ellie is a type-safe programing language that runs on embedded and sandboxed environments. |
+| [darklua] | 36 | ☀️ Active | A command line tool that transforms Lua code |
 | [ucg] | 31 | ☀️ Active | A Universal Configuration Grammar |
-| [darklua] | 28 | ☀️ Active | Transform Lua 5.1 and Roblox Lua scripts using rules. |
-| [Ry] | 22 | ☀️ Active | 👁‍🗨 An open source WIP programming language for web development with expressive type system that makes it easy to build reliable and efficient software. |
-| [Ellie] | 21 | ☀️ Active | Ellie is a type-safe programming language that runs on embedded and sandboxed environments. |
-| [Pr47] | 21 | ☀️ Active | The formal development repository for Pr47 |
-| [Terbium] | 18 | ☀️ Active | A high-level language that doesn't compromise in performance, made with Rust. |
-| [Wright] | 18 | ☀️ Active | The wright programming language (WIP) |
-| [The Force] | 15 | ☀️ Active | A Star Wars themed programming language |
-| [Sligh] | 9 | ☀️ Active | A language for model transformation |
-| [Tethys] | 6 | ☀️ Active | A toy functional programming language with a System F-based core calculus |
+| [The Force] | 21 | ☀️ Active | A Star Wars themed programming language |
+| [Wright] | 20 | ☀️ Active | The wright programming language (WIP) |
+| [Terbium] | 19 | ☀️ Active | A high-level language that doesn't compromise in performance, made with Rust. |
+| [Tethys] | 11 | ☀️ Active | A toy functional programming language with a System F-based core calculus |
+| [Sligh] | 10 | ☀️ Active | A language for certifying specification |
 | [loxidation] | 4 | ☀️ Active | Lox bytecode compiler and VM in Rust |
-| [PopperLang] | 0 | ☀️ Active | Popper is an functional programming language designed to simplify the development process by providing a clear and concise syntax written in Rust |
-| [Passerine] | 1,013 | 🌙 Inactive | A small extensible programming language designed for concise expression with little code. |
-| [ClojureRS] | 909 | 🌙 Inactive | Clojure, implemented atop Rust (unofficial) |
-| [Ketos] | 723 | 🌙 Inactive | Lisp dialect scripting and extension language for Rust programs |
-| [Astro] | 680 | 🌙 Inactive | A fun safe language for rapid prototyping and high performance applications |
-| [Pikelet] | 590 | 🌙 Inactive | A friendly little systems language with first-class types. Very WIP! 🚧 🚧 🚧 |
-| [Starlight] | 461 | 🌙 Inactive | JS engine in Rust |
-| [CalcuLaTeX] | 379 | 🌙 Inactive | A pretty printing calculator language with support for units. Makes calculations easier and more presentable with real time LaTeX output, along with support for units, variables, and mathematical functions. |
-| [Wain] | 333 | 🌙 Inactive | WebAssembly implementation from scratch in Safe Rust with zero dependencies |
-| [Monkey-Rust] | 296 | 🌙 Inactive | An interpreter for the Monkey programming language written in Rust |
-| [Sphinx] | 287 | 🌙 Inactive | An interpreter for a simple dynamic language written in Rust |
-| [Eldiro] | 212 | 🌙 Inactive | Learn to make your own programming language with Rust |
-| [Loxcraft] | 193 | 🌙 Inactive | Language tooling for the Lox programming language. |
-| [atto] | 140 | 🌙 Inactive | An insanely simple self-hosted functional programming language |
-| [Minitt] | 102 | 🌙 Inactive | Dependently-typed lambda calculus, Mini-TT, extended and implemented in Rust |
-| [Voile] | 89 | 🌙 Inactive | Dependently-typed row-polymorphic programming language, evolved from minitt-rs |
-| [Jazz] | 86 | 🌙 Inactive | Jazz - modern and fast programming language. |
+| [PopperLang] | 1 | ☀️ Active | The CLI that group all project to one to finally make the Popper-lang  |
+| [rusch] | 1 | ☀️ Active | Minimal Scheme implemented in Rust |
+| [Orion] | 0 | ☀️ Active | None |
+| [Passerine] | 1,022 | 🌙 Inactive | A small extensible programming language designed for concise expression with little code. |
+| [ClojureRS] | 922 | 🌙 Inactive | Clojure, implemented atop Rust (unofficial) |
+| [Ketos] | 742 | 🌙 Inactive | Lisp dialect scripting and extension language for Rust programs |
+| [Pikelet] | 601 | 🌙 Inactive | A friendly little systems language with first-class types. Very WIP! 🚧 🚧 🚧 |
+| [Starlight] | 480 | 🌙 Inactive | JS engine in Rust |
+| [Wu] | 456 | 🌙 Inactive | 🐉 A practical game and data language |
+| [CalcuLaTeX] | 385 | 🌙 Inactive | A pretty printing calculator language with support for units. Makes calculations easier and more presentable with real time LaTeX output, along with support for units, variables, and mathematical functions. |
+| [Monkey-Rust] | 329 | 🌙 Inactive | An interpreter for the Monkey programming language written in Rust |
+| [Sphinx] | 285 | 🌙 Inactive | An intepreter for a simple dynamic language written in Rust |
+| [Eldiro] | 229 | 🌙 Inactive | Learn to make your own programming language with Rust |
+| [Loxcraft] | 209 | 🌙 Inactive | Language tooling for the Lox programming language. |
+| [crafting-interpreters-rs] | 206 | 🌙 Inactive | Crafting Interpreters in Rust |
+| [TablaM] | 175 | 🌙 Inactive | The practical relational programing language for data-oriented applications |
+| [atto] | 143 | 🌙 Inactive | An insanely simple self-hosted functional programming language |
+| [Minitt] | 111 | 🌙 Inactive | Dependently-typed lambda calculus, Mini-TT, extended and implemented in Rust |
+| [Boson] | 108 | 🌙 Inactive | A hybrid programming language written in Rust.  |
+| [Voile] | 93 | 🌙 Inactive | Dependently-typed row-polymorphic programming language, evolved from minitt-rs |
+| [Jazz] | 89 | 🌙 Inactive | Jazz - modern and fast programming language. |
 | [Rust-lisp] | 83 | 🌙 Inactive | A small Lisp interpreter written in Rust. Work in progress. |
-| [Rust-Prolog] | 78 | 🌙 Inactive | Rust implementation of prolog based on miniprolog: http://andrej.com/plzoo/html/miniprolog.html |
-| [diatom] | 72 | 🌙 Inactive | A dynamic typed scripting language for embedded use in applications. This project is yet another attempt of being a "better" lua. |
-| [ssp16asm] | 63 | 🌙 Inactive | A collection of development tools targetting SEGA's SVP chip found in the Mega Drive/Genesis version of Virtua Racing. |
-| [Darksecond/lox] | 59 | 🌙 Inactive | A rust implementation of the lox language |
-| [rulox] | 55 | 🌙 Inactive | Implementation in Rust of lox, the language described in Crafting Interpreters |
-| [Crunch] | 51 | 🌙 Inactive | A strongly & statically typed systems level language focused on ease of use, portability and speed, built for the modern age. |
+| [Rust-Prolog] | 79 | 🌙 Inactive | Rust implementation of prolog based on miniprolog: http://andrej.com/plzoo/html/miniprolog.html |
+| [ssp16asm] | 73 | 🌙 Inactive | A collection of development tools targetting SEGA's SVP chip found in the Mega Drive/Genesis version of Virtua Racing. |
+| [diatom] | 72 | 🌙 Inactive | The diatom programming language |
+| [rulox] | 61 | 🌙 Inactive | Implementation in Rust of lox, the language described in Crafting Interpreters |
+| [Crunch] | 52 | 🌙 Inactive | A strongly & statically typed systems level language focused on ease of use, portability and speed, built for the modern age. |
 | [Blazescript] | 48 | 🌙 Inactive | AOT compiled object oriented programming language |
-| [rodaine/rlox] | 36 | 🌙 Inactive | Lox Interpreter/REPL written in Rust |
-| [Schwift] | 30 | 🌙 Inactive | An actual programming language for some reason |
-| [lox-rs] | 27 | 🌙 Inactive | A Lox Interpreter in Rust |
-| [Lisp.rs] | 26 | 🌙 Inactive | Scheme Interpreter in Rust |
+| [Chili] | 45 | 🌙 Inactive | General-purpose, compiled programming language, focused on productivity, expressiveness and joy of programming™ |
+| [rodaine/rlox] | 37 | 🌙 Inactive | Lox Interpreter/REPL written in Rust |
+| [Foolang] | 36 | 🌙 Inactive | A toy programming language. |
+| [tox] | 35 | 🌙 Inactive | Tox is a statically typed version programming language that is written in rust. |
+| [Schwift] | 31 | 🌙 Inactive | An actual programming language for some reason |
+| [lox-rs] | 28 | 🌙 Inactive | A Lox Interpreter in Rust |
+| [Lisp.rs] | 25 | 🌙 Inactive | Scheme Interpreter in Rust |
+| [Pr47] | 21 | 🌙 Inactive | The formal development repository for Pr47 |
 | [Synthizer] | 20 | 🌙 Inactive | A simple, experimental functional language for real time additive audio synthesis. |
+| [cat-lox] | 18 | 🌙 Inactive | A tree-walk lox interpreter written in Rust. |
 | [rctcwyvrn/rlox] | 16 | 🌙 Inactive | Rust implementation of the bytecode VM (clox) from https://craftinginterpreters.com/ |
-| [cat-lox] | 15 | 🌙 Inactive | A tree-walk lox interpreter written in Rust. |
-| [Arn] | 13 | 🌙 Inactive | A functional golfing language |
+| [Arn] | 15 | 🌙 Inactive | A functional golfing language |
 | [Radicle] | 11 | 🌙 Inactive | an ur-lisp interpreter written in Rust |
-| [Lang] | 8 | 🌙 Inactive | An imperative programming language written in Rust |
-| [loxr] | 7 | 🌙 Inactive | A Rust interpreter for the Lox language |
+| [loxr] | 8 | 🌙 Inactive | A Rust interpreter for the Lox language |
+| [Lang] | 7 | 🌙 Inactive | An imperative programming language written in Rust |
+| [radogost/rlox] | 7 | 🌙 Inactive | An implementation of lox from the great book http://craftinginterpreters.com implemented in Rust |
 | [minipyth] | 7 | 🌙 Inactive | A minimalist programming language |
 | [Iron] | 6 | 🌙 Inactive | A Lisp-based language written in Rust |
-| [radogost/rlox] | 6 | 🌙 Inactive | An implementation of lox from the great book http://craftinginterpreters.com implemented in Rust |
 | [loxrs] | 6 | 🌙 Inactive | [old] Crafting Interpreters in Rust (Part II: A tree-walk interpreter) |
 | [relox] | 6 | 🌙 Inactive | Rust port of the jlox interpreter |
-| [rox] | 5 | 🌙 Inactive | A Rust port of Crafting Interpreters |
+| [🌌] | 6 | 🌙 Inactive | What if identifiers could be anything? Langjam submission |
+| [justinmayhew/lox] | 5 | 🌙 Inactive | A Rust implementation of Lox from Crafting Interpreters |
 | [sasurau4/lox-rust] | 5 | 🌙 Inactive | Interpreter for lox written by rust |
-| [🌌] | 5 | 🌙 Inactive | What if identifiers could be anything? Langjam submission |
-| [justinmayhew/lox] | 4 | 🌙 Inactive | A Rust implementation of Lox from Crafting Interpreters |
-| [lax] | 3 | 🌙 Inactive | a lox interpreter |
+| [lax] | 4 | 🌙 Inactive | a lox interpreter |
+| [rox] | 4 | 🌙 Inactive | A Rust port of Crafting Interpreters |
+| [cloxrs] | 3 | 🌙 Inactive | Lox implementation written in Rust |
 | [yarli] | 3 | 🌙 Inactive | Yet Another Rusty Lox Interpreter |
-| [cloxrs] | 2 | 🌙 Inactive | Lox implementation written in Rust |
 | [nt591/lox-rust] | 2 | 🌙 Inactive | A Rust implementation of the Crafting Interpreters bytecode VM |
 | [roxt] | 2 | 🌙 Inactive | A Lox interpreter written in Rust |
-| [rusch] | 1 | 🌙 Inactive | Minimal Scheme interpreter implemented in Rust |
 
 *: Parcel is a large project of which the JavaScript transformer (written in Rust)
 is a small part. The "stars" number here reflects the whole project, which is
@@ -252,16 +252,17 @@ broader than a programming language project.
 [Veryl]: https://github.com/dalance/veryl
 [TablaM]: https://github.com/Tablam/TablaM
 [PopperLang]: https://github.com/popper-lang/popper-lang
-[nu]: https://www.nushell.sh/book/nu_fundamentals.html
 [Roc]: https://github.com/roc-lang/roc
-[Ry]: https://github.com/quantumatic/
+[Move]: https://github.com/move-language/move
+[Typst]: https://github.com/typst/typst
+[Stellar]: https://github.com/quantumatic/stellar
 [Oriel]: https://github.com/wojciech-graj/oriel
 [Duckscript]: https://github.com/sagiegurari/duckscript
 [Terbium]: https://github.com/terbium-lang/terbium
 [Loxcraft]: https://github.com/ajeetdsouza/loxcraft
-[Tvix]: https://code.tvl.fyi/tree/tvix/eval
 [Move]: https://github.com/move-language/move
 [rusch]: https://github.com/twolodzko/rusch
 [ClojureRS]: https://github.com/clojure-rs/ClojureRS
 [diatom]: https://github.com/diatom-lang/diatom
 [darklua]: https://github.com/seaofvoices/darklua
+[Tvix]: https://github.com/tvlfyi/tvix

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Then it can be included in this list!
 | [Parcel JavaScript Transformer] | 42,109 | ☀️ Active | The zero configuration build tool for the web. 📦🚀 |
 | [swc] | 26,551 | ☀️ Active | Rust-based platform for the Web |
 | [nu] | 25,568 | ☀️ Active | Scripting language of [nushell](https://github.com/nushell/nushell). The goal of this project is to take the Unix philosophy of shells, where pipes connect simple commands together, and bring it to the modern style of development. Thus, rather than being either a shell, or a programming language, Nushell connects both by bringing a rich programming language and a full-featured shell together into one package. |
+| [Typst] | 23,742 | ☀️ Active | A new markup-based typesetting system that is powerful and easy to learn. |
 | [RustPython] | 14,414 | ☀️ Active | A Python Interpreter written in Rust |
 | [Gleam] | 4,720 | ☀️ Active | ⭐️ A friendly language for building type-safe, scalable systems! |
 | [Melody] | 4,072 | ☀️ Active | Melody is a language that compiles to regular expressions and aims to be more easily readable and maintainable |

--- a/languages.json
+++ b/languages.json
@@ -789,5 +789,53 @@
         "description": "A new markup-based typesetting system that is powerful and easy to learn.",
         "stars": 23742,
         "active": true
+    },
+    {
+        "name": "Stellar",
+        "url": "https://github.com/quantumatic/stellar"
+    },
+    {
+        "name": "Oriel",
+        "url": "https://github.com/wojciech-graj/oriel"
+    },
+    {
+        "name": "Duckscript",
+        "url": "https://github.com/sagiegurari/duckscript"
+    },
+    {
+        "name": "Terbium",
+        "url": "https://github.com/terbium-lang/terbium"
+    },
+    {
+        "name": "Loxcraft",
+        "url": "https://github.com/ajeetdsouza/loxcraft"
+    },
+    {
+        "name": "Tvix",
+        "url": "https://code.tvl.fyi/tree/tvix/eval"
+    },
+    {
+        "name": "Move",
+        "url": "https://github.com/move-language/move"
+    },
+    {
+        "name": "rusch",
+        "url": "https://github.com/twolodzko/rusch"
+    },
+    {
+        "name": "ClojureRS",
+        "url": "https://github.com/clojure-rs/ClojureRS"
+    },
+    {
+        "name": "diatom",
+        "url": "https://github.com/diatom-lang/diatom"
+    },
+    {
+        "name": "darklua",
+        "url": "https://github.com/seaofvoices/darklua"
+    },
+    {
+        "name": "Tvix",
+        "url": "https://github.com/tvlfyi/tvix"
     }
 ]

--- a/languages.json
+++ b/languages.json
@@ -782,5 +782,12 @@
         "description": "A programming language for writing safe and smart contracts in blockchain.",
         "stars": 1989,
         "active": true
+    },
+    {
+        "name": "Typst",
+        "url": "https://github.com/typst/typst",
+        "description": "A new markup-based typesetting system that is powerful and easy to learn.",
+        "stars": 23742,
+        "active": true
     }
 ]

--- a/languages.json
+++ b/languages.json
@@ -3,49 +3,49 @@
         "name": "Dyon",
         "url": "https://github.com/pistondevelopers/dyon",
         "description": "A rusty dynamically typed scripting language",
-        "stars": 1555,
+        "stars": 1640,
         "active": true
     },
     {
         "name": "Ketos",
         "url": "https://github.com/murarth/ketos",
         "description": "Lisp dialect scripting and extension language for Rust programs",
-        "stars": 723,
+        "stars": 742,
         "active": false
     },
     {
         "name": "Rhai",
         "url": "https://github.com/jonathandturner/rhai",
         "description": "Rhai - An embedded scripting language for Rust.",
-        "stars": 2589,
+        "stars": 3180,
         "active": true
     },
     {
         "name": "Gluon",
         "url": "https://github.com/gluon-lang/gluon",
         "description": "A static, type inferred and embeddable language written in Rust.",
-        "stars": 2783,
+        "stars": 3019,
         "active": true
     },
     {
         "name": "Antimony",
         "url": "https://github.com/antimony-lang/antimony",
         "description": "The Antimony programming language",
-        "stars": 103,
+        "stars": 115,
         "active": true
     },
     {
         "name": "Tao",
         "url": "https://github.com/zesterer/tao",
         "description": "A statically-typed functional language with generics, typeclasses, sum types, pattern-matching, first-class functions, currying, algebraic effects, associated types, good diagnostics, etc.",
-        "stars": 880,
+        "stars": 1030,
         "active": true
     },
     {
         "name": "Lang",
         "url": "https://github.com/gsingh93/lang",
         "description": "An imperative programming language written in Rust",
-        "stars": 8,
+        "stars": 7,
         "active": false
     },
     {
@@ -59,7 +59,7 @@
         "name": "atto",
         "url": "https://github.com/zesterer/atto",
         "description": "An insanely simple self-hosted functional programming language",
-        "stars": 140,
+        "stars": 143,
         "active": false
     },
     {
@@ -73,7 +73,7 @@
         "name": "Lisp.rs",
         "url": "https://github.com/jsdf/lisp.rs",
         "description": "Scheme Interpreter in Rust",
-        "stars": 26,
+        "stars": 25,
         "active": false
     },
     {
@@ -87,7 +87,7 @@
         "name": "Rust-Prolog",
         "url": "https://github.com/dagit/rust-prolog",
         "description": "Rust implementation of prolog based on miniprolog: http://andrej.com/plzoo/html/miniprolog.html",
-        "stars": 78,
+        "stars": 79,
         "active": false
     },
     {
@@ -101,21 +101,21 @@
         "name": "rtforth",
         "url": "https://github.com/chengchangwu/rtforth",
         "description": "Forth implemented in Rust for realtime application",
-        "stars": 65,
+        "stars": 78,
         "active": true
     },
     {
         "name": "Schwift",
         "url": "https://github.com/natemara/schwift",
         "description": "An actual programming language for some reason",
-        "stars": 30,
+        "stars": 31,
         "active": false
     },
     {
         "name": "Gleam",
         "url": "https://github.com/gleam-lang/gleam",
         "description": "\u2b50\ufe0f A friendly language for building type-safe, scalable systems!",
-        "stars": 4720,
+        "stars": 5580,
         "active": true
     },
     {
@@ -129,245 +129,245 @@
         "name": "Starlark",
         "url": "https://github.com/facebookexperimental/starlark-rust",
         "description": "A Rust implementation of the Starlark language",
-        "stars": 388,
+        "stars": 537,
         "active": true
     },
     {
         "name": "Crunch",
         "url": "https://github.com/Kixiron/crunch-lang",
         "description": "A strongly & statically typed systems level language focused on ease of use, portability and speed, built for the modern age.",
-        "stars": 51,
+        "stars": 52,
         "active": false
     },
     {
         "name": "Eldiro",
         "url": "https://github.com/arzg/eldiro",
         "description": "Learn to make your own programming language with Rust",
-        "stars": 212,
+        "stars": 229,
         "active": false
     },
     {
         "name": "Starlight",
         "url": "https://github.com/Starlight-JS/Starlight",
         "description": "JS engine in Rust",
-        "stars": 461,
+        "stars": 480,
         "active": false
     },
     {
         "name": "Differential Datalog",
         "url": "https://github.com/vmware/differential-datalog",
         "description": "DDlog is a programming language for incremental computation. It is well suited for writing programs that continuously update their output in response to input changes. A DDlog programmer does not write incremental algorithms; instead they specify the desired input-output mapping in a declarative manner.",
-        "stars": 1248,
+        "stars": 1293,
         "active": true
     },
     {
         "name": "Boa",
         "url": "https://github.com/boa-dev/boa",
         "description": "Boa is an embeddable and experimental Javascript engine written in Rust. Currently, it has support for some of the language.",
-        "stars": 3813,
+        "stars": 4345,
         "active": true
     },
     {
         "name": "Nickel",
         "url": "https://github.com/tweag/nickel",
         "description": "Better configuration for less",
-        "stars": 1314,
+        "stars": 1912,
         "active": true
     },
     {
         "name": "Artichoke",
         "url": "https://github.com/artichoke/artichoke",
         "description": "\ud83d\udc8e Artichoke is a Ruby made with Rust",
-        "stars": 2863,
+        "stars": 2955,
         "active": true
     },
     {
         "name": "Ellie",
         "url": "https://github.com/behemehal/Ellie-Language",
-        "description": "Ellie is a type-safe programming language that runs on embedded and sandboxed environments.",
-        "stars": 21,
+        "description": "Ellie is a type-safe programing language that runs on embedded and sandboxed environments.",
+        "stars": 39,
         "active": true
     },
     {
         "name": "Mun",
         "url": "https://github.com/mun-lang/mun",
         "description": "Source code for the Mun language and runtime.",
-        "stars": 1518,
+        "stars": 1644,
         "active": true
     },
     {
         "name": "Koto",
         "url": "https://github.com/koto-lang/koto",
         "description": "A simple, expressive, embeddable programming language, made with Rust",
-        "stars": 326,
+        "stars": 354,
         "active": true
     },
     {
         "name": "Ante",
         "url": "https://github.com/jfecher/ante",
         "description": "A safe, easy systems language",
-        "stars": 1592,
+        "stars": 1693,
         "active": true
     },
     {
         "name": "Astro",
         "url": "https://github.com/astrolang/astro",
         "description": "A fun safe language for rapid prototyping and high performance applications",
-        "stars": 680,
-        "active": false
+        "stars": 712,
+        "active": true
     },
     {
         "name": "Rune",
         "url": "https://github.com/rune-rs/rune",
         "description": "An embeddable dynamic programming language for Rust.",
-        "stars": 1144,
+        "stars": 1387,
         "active": true
     },
     {
         "name": "Pikelet",
         "url": "https://github.com/pikelet-lang/pikelet",
         "description": "A friendly little systems language with first-class types. Very WIP! \ud83d\udea7 \ud83d\udea7 \ud83d\udea7",
-        "stars": 590,
+        "stars": 601,
         "active": false
     },
     {
         "name": "Passerine",
         "url": "https://github.com/vrtbl/passerine",
         "description": "A small extensible programming language designed for concise expression with little code.",
-        "stars": 1013,
+        "stars": 1022,
         "active": false
     },
     {
         "name": "CSML",
         "url": "https://github.com/CSML-by-Clevy/csml-engine",
         "description": "CSML is an easy-to-use chatbot programming language and framework.",
-        "stars": 660,
+        "stars": 692,
         "active": true
     },
     {
         "name": "frawk",
         "url": "https://github.com/ezrosent/frawk",
         "description": "an efficient awk-like language",
-        "stars": 1069,
+        "stars": 1144,
         "active": true
     },
     {
         "name": "SPWN",
         "url": "https://github.com/Spu7Nix/SPWN-language",
         "description": "A language for Geometry Dash triggers",
-        "stars": 627,
+        "stars": 766,
         "active": true
     },
     {
         "name": "Orion",
         "url": "https://github.com/orion-lang/orion",
-        "description": "Orion is a high level, purely functional programming language with a LISP based syntax.",
-        "stars": 229,
+        "description": null,
+        "stars": 0,
         "active": true
     },
     {
         "name": "Wu",
         "url": "https://github.com/wu-lang/wu",
         "description": "\ud83d\udc09 A practical game and data language",
-        "stars": 440,
-        "active": true
+        "stars": 456,
+        "active": false
     },
     {
         "name": "Wain",
         "url": "https://github.com/rhysd/wain",
         "description": "WebAssembly implementation from scratch in Safe Rust with zero dependencies",
-        "stars": 333,
-        "active": false
+        "stars": 374,
+        "active": true
     },
     {
         "name": "Leo",
         "url": "https://github.com/AleoHQ/leo",
         "description": "\ud83e\udd81 The Leo Programming Language. A Programming Language for Formally Verified, Zero-Knowledge Applications",
-        "stars": 401,
+        "stars": 3222,
         "active": true
     },
     {
         "name": "EndBASIC",
         "url": "https://github.com/jmmv/endbasic",
         "description": "BASIC environment with a REPL, a web interface, a graphical console, and RPi support written in Rust",
-        "stars": 232,
+        "stars": 288,
         "active": true
     },
     {
         "name": "Voile",
         "url": "https://github.com/owo-lang/voile-rs",
         "description": "Dependently-typed row-polymorphic programming language, evolved from minitt-rs",
-        "stars": 89,
+        "stars": 93,
         "active": false
     },
     {
         "name": "Jazz",
         "url": "https://github.com/jazz-lang/Jazz",
         "description": "Jazz - modern and fast programming language.",
-        "stars": 86,
+        "stars": 89,
         "active": false
     },
     {
         "name": "Minitt",
         "url": "https://github.com/owo-lang/minitt-rs",
         "description": "Dependently-typed lambda calculus, Mini-TT, extended and implemented in Rust",
-        "stars": 102,
+        "stars": 111,
         "active": false
     },
     {
         "name": "cat-lox",
         "url": "https://github.com/AaronStGeorge/cat-lox",
         "description": "A tree-walk lox interpreter written in Rust.",
-        "stars": 15,
+        "stars": 18,
         "active": false
     },
     {
         "name": "lax",
         "url": "https://github.com/alisww/lax",
         "description": "a lox interpreter",
-        "stars": 3,
+        "stars": 4,
         "active": false
     },
     {
         "name": "cloxrs",
         "url": "https://github.com/anellie/cloxrs",
         "description": "Lox implementation written in Rust",
-        "stars": 2,
+        "stars": 3,
         "active": false
     },
     {
         "name": "rox",
         "url": "https://github.com/brightly-salty/rox",
         "description": "A Rust port of Crafting Interpreters",
-        "stars": 5,
+        "stars": 4,
         "active": false
     },
     {
         "name": "Darksecond/lox",
         "url": "https://github.com/darksecond/lox",
         "description": "A rust implementation of the lox language",
-        "stars": 59,
-        "active": false
+        "stars": 84,
+        "active": true
     },
     {
         "name": "loxr",
         "url": "https://github.com/HarveyHunt/loxr",
         "description": "A Rust interpreter for the Lox language",
-        "stars": 7,
+        "stars": 8,
         "active": false
     },
     {
         "name": "lox-rs",
         "url": "https://github.com/jeschkies/lox-rs",
         "description": "A Lox Interpreter in Rust",
-        "stars": 27,
+        "stars": 28,
         "active": false
     },
     {
         "name": "Laythe",
         "url": "https://github.com/Laythe-lang/Laythe",
         "description": "A gradually typed language originally based on the crafting interpreters series ",
-        "stars": 59,
+        "stars": 63,
         "active": true
     },
     {
@@ -375,7 +375,7 @@
         "url": "https://github.com/Lapz/tox",
         "description": "Tox is a statically typed version programming language that is written in rust.",
         "stars": 35,
-        "active": true
+        "active": false
     },
     {
         "name": "loxidation",
@@ -388,14 +388,14 @@
         "name": "rulox",
         "url": "https://github.com/mariosangiorgio/rulox",
         "description": "Implementation in Rust of lox, the language described in Crafting Interpreters",
-        "stars": 55,
+        "stars": 61,
         "active": false
     },
     {
         "name": "justinmayhew/lox",
         "url": "https://github.com/justinmayhew/lox",
         "description": "A Rust implementation of Lox from Crafting Interpreters",
-        "stars": 4,
+        "stars": 5,
         "active": false
     },
     {
@@ -409,7 +409,7 @@
         "name": "radogost/rlox",
         "url": "https://github.com/radogost/rlox",
         "description": "An implementation of lox from the great book http://craftinginterpreters.com implemented in Rust",
-        "stars": 6,
+        "stars": 7,
         "active": false
     },
     {
@@ -423,7 +423,7 @@
         "name": "rodaine/rlox",
         "url": "https://github.com/rodaine/rlox",
         "description": "Lox Interpreter/REPL written in Rust",
-        "stars": 36,
+        "stars": 37,
         "active": false
     },
     {
@@ -451,8 +451,8 @@
         "name": "crafting-interpreters-rs",
         "url": "https://github.com/tdp2110/crafting-interpreters-rs",
         "description": "Crafting Interpreters in Rust",
-        "stars": 160,
-        "active": true
+        "stars": 206,
+        "active": false
     },
     {
         "name": "roxt",
@@ -471,43 +471,43 @@
     {
         "name": "Sligh",
         "url": "https://github.com/amw-zero/sligh",
-        "description": "A language for model transformation",
-        "stars": 9,
+        "description": "A language for certifying specification",
+        "stars": 10,
         "active": true
     },
     {
         "name": "Monkey-Rust",
         "url": "https://github.com/Rydgel/monkey-rust",
         "description": "An interpreter for the Monkey programming language written in Rust",
-        "stars": 296,
+        "stars": 329,
         "active": false
     },
     {
         "name": "Parcel JavaScript Transformer",
         "url": "https://github.com/parcel-bundler/parcel",
         "description": "The zero configuration build tool for the web. \ud83d\udce6\ud83d\ude80",
-        "stars": 42109,
+        "stars": 42819,
         "active": true
     },
     {
         "name": "swc",
         "url": "https://github.com/swc-project/swc",
         "description": "Rust-based platform for the Web",
-        "stars": 26551,
+        "stars": 29050,
         "active": true
     },
     {
         "name": "Calcit",
         "url": "https://github.com/calcit-lang/calcit_runner.rs",
-        "description": "Lisp compiling to JavaScript ES Modules",
-        "stars": 71,
+        "description": "Indentation-based ClojureScript compiling to JavaScript ES Modules",
+        "stars": 92,
         "active": true
     },
     {
         "name": "Steel",
         "url": "https://github.com/mattwparas/steel",
         "description": "An embedded scheme interpreter in Rust",
-        "stars": 121,
+        "stars": 602,
         "active": true
     },
     {
@@ -521,7 +521,7 @@
         "name": "goscript",
         "url": "https://github.com/oxfeeefeee/goscript",
         "description": "An alternative implementation of Golang specs, written in Rust for embedding or wrapping.",
-        "stars": 1421,
+        "stars": 1497,
         "active": true
     },
     {
@@ -529,27 +529,27 @@
         "url": "https://github.com/Pr47/Pr47",
         "description": "The formal development repository for Pr47",
         "stars": 21,
-        "active": true
+        "active": false
     },
     {
         "name": "The Force",
         "url": "https://github.com/mirdaki/theforce",
         "description": "A Star Wars themed programming language",
-        "stars": 15,
+        "stars": 21,
         "active": true
     },
     {
         "name": "\ud83c\udf0c",
         "url": "https://github.com/mrozycki/space-lang",
         "description": "What if identifiers could be anything? Langjam submission",
-        "stars": 5,
+        "stars": 6,
         "active": false
     },
     {
         "name": "Arn",
         "url": "https://github.com/ZippyMagician/Arn",
         "description": "A functional golfing language",
-        "stars": 13,
+        "stars": 15,
         "active": false
     },
     {
@@ -563,224 +563,217 @@
         "name": "Parcel CSS",
         "url": "https://github.com/parcel-bundler/parcel-css",
         "description": "An extremely fast CSS parser, transformer, bundler, and minifier written in Rust.",
-        "stars": 3351,
+        "stars": 5109,
         "active": true
     },
     {
         "name": "Scryer Prolog",
         "url": "https://github.com/mthom/scryer-prolog",
         "description": "A modern Prolog implementation written mostly in Rust.",
-        "stars": 1655,
+        "stars": 1799,
         "active": true
     },
     {
         "name": "CalcuLaTeX",
         "url": "https://github.com/mkhan45/CalcuLaTeX",
         "description": "A pretty printing calculator language with support for units. Makes calculations easier and more presentable with real time LaTeX output, along with support for units, variables, and mathematical functions.",
-        "stars": 379,
+        "stars": 385,
         "active": false
     },
     {
         "name": "RustPython",
         "url": "https://github.com/RustPython/RustPython",
         "description": "A Python Interpreter written in Rust",
-        "stars": 14414,
+        "stars": 15920,
         "active": true
     },
     {
         "name": "Melody",
         "url": "https://github.com/yoav-lavi/melody",
-        "description": "Melody is a language that compiles to regular expressions and aims to be more easily readable and maintainable",
-        "stars": 4072,
+        "description": "Melody is a language that compiles to regular expressions and aims to be more readable and maintainable",
+        "stars": 4520,
         "active": true
     },
     {
         "name": "Fe",
         "url": "https://github.com/ethereum/fe",
         "description": "Emerging smart contract language for the Ethereum blockchain.",
-        "stars": 1408,
+        "stars": 1518,
         "active": true
     },
     {
         "name": "Sway",
         "url": "https://github.com/FuelLabs/sway",
         "description": "\ud83c\udf34 Empowering everyone to build reliable and efficient smart contracts.",
-        "stars": 389,
+        "stars": 37683,
         "active": true
     },
     {
         "name": "Sphinx",
         "url": "https://github.com/mwerezak/sphinx-lang",
-        "description": "An interpreter for a simple dynamic language written in Rust",
-        "stars": 287,
+        "description": "An intepreter for a simple dynamic language written in Rust",
+        "stars": 285,
         "active": false
     },
     {
         "name": "Butter",
         "url": "https://github.com/neverRare/butter",
         "description": "A tasty language for building efficient software. Currently work in progress!",
-        "stars": 114,
+        "stars": 112,
         "active": true
     },
     {
         "name": "Calypso",
         "url": "https://github.com/calypso-lang/calypso",
         "description": "Calypso is a mostly imperative language with some functional influences that is focused on flexibility and simplicity.",
-        "stars": 57,
+        "stars": 60,
         "active": true
     },
     {
         "name": "Tethys",
         "url": "https://github.com/ThePuzzlemaker/tethys",
         "description": "A toy functional programming language with a System F-based core calculus",
-        "stars": 6,
+        "stars": 11,
         "active": true
     },
     {
         "name": "Chili",
         "url": "https://github.com/r0nsha/chili",
         "description": "General-purpose, compiled programming language, focused on productivity, expressiveness and joy of programming\u2122",
-        "stars": 41,
-        "active": true
+        "stars": 45,
+        "active": false
     },
     {
         "name": "Foolang",
         "url": "https://github.com/nikodemus/foolang",
         "description": "A toy programming language.",
-        "stars": 33,
-        "active": true
+        "stars": 36,
+        "active": false
     },
     {
         "name": "Rust",
         "url": "https://github.com/rust-lang/rust",
         "description": "Empowering everyone to build reliable and efficient software.",
-        "stars": 78830,
+        "stars": 87702,
         "active": true
     },
     {
         "name": "Jakt",
         "url": "https://github.com/SerenityOS/jakt",
         "description": "The Jakt Programming Language",
-        "stars": 2484,
+        "stars": 2693,
         "active": true
     },
     {
         "name": "Inko",
         "url": "https://github.com/YorickPeterse/inko",
-        "description": "A language for building concurrent software with confidence. This is a read-only mirror of https://gitlab.com/inko-lang/inko",
-        "stars": 217,
+        "description": "A language for building concurrent software with confidence",
+        "stars": 620,
         "active": true
     },
     {
         "name": "Erg",
         "url": "https://github.com/erg-lang/erg",
         "description": "A statically typed language that can deeply improve the Python ecosystem",
-        "stars": 2130,
+        "stars": 2369,
         "active": true
     },
     {
         "name": "KCLVM",
         "url": "https://github.com/KusionStack/KCLVM",
-        "description": "A constraint-based record & functional language mainly used in configuration and policy scenarios.",
-        "stars": 474,
+        "description": "KCL Language Core. KCL is a constraint-based record & functional language mainly used in configuration and policy scenarios. (CNCF Sandbox Project). https://kcl-lang.io",
+        "stars": 948,
         "active": true
     },
     {
         "name": "Tokay",
         "url": "https://github.com/tokay-lang/tokay",
         "description": "Tokay is a programming language designed for ad-hoc parsing, inspired by awk.",
-        "stars": 197,
+        "stars": 220,
         "active": true
     },
     {
         "name": "Deno",
         "url": "https://github.com/denoland/deno",
         "description": "A modern runtime for JavaScript and TypeScript.",
-        "stars": 88397,
+        "stars": 91548,
         "active": true
     },
     {
         "name": "Lurk",
         "url": "https://github.com/lurk-lang/lurk-rs",
-        "description": null,
-        "stars": 192,
+        "description": "Lurk is a Turing-complete programming language for recursive zk-SNARKs.  It is a statically scoped dialect of Lisp, influenced by Scheme and Common Lisp.",
+        "stars": 348,
         "active": true
     },
     {
         "name": "Boson",
         "url": "https://github.com/Narasimha1997/boson-lang",
         "description": "A hybrid programming language written in Rust. ",
-        "stars": 103,
-        "active": true
+        "stars": 108,
+        "active": false
     },
     {
         "name": "Kind",
         "url": "https://github.com/HigherOrderCO/Kind",
         "description": "A next-gen functional language",
-        "stars": 3025,
+        "stars": 3321,
         "active": true
     },
     {
         "name": "Wright",
         "url": "https://github.com/Alfriadox/wright-lang",
         "description": "The wright programming language (WIP)",
-        "stars": 18,
+        "stars": 20,
         "active": true
     },
     {
         "name": "ssp16asm",
         "url": "https://github.com/jdesiloniz/svpdev",
         "description": "A collection of development tools targetting SEGA's SVP chip found in the Mega Drive/Genesis version of Virtua Racing.",
-        "stars": 63,
+        "stars": 73,
         "active": false
     },
     {
         "name": "jsparagus",
         "url": "https://github.com/mozilla-spidermonkey/jsparagus",
         "description": "Experimental JS parser-generator project.",
-        "stars": 372,
+        "stars": 410,
         "active": true
     },
     {
         "name": "Veryl",
         "url": "https://github.com/dalance/veryl",
         "description": "Veryl: A Modern Hardware Description Language",
-        "stars": 162,
+        "stars": 216,
         "active": true
     },
     {
         "name": "TablaM",
         "url": "https://github.com/Tablam/TablaM",
-        "description": "The practical relational programming language for data-oriented applications",
-        "stars": 154,
-        "active": true
+        "description": "The practical relational programing language for data-oriented applications",
+        "stars": 175,
+        "active": false
     },
     {
         "name": "PopperLang",
         "url": "https://github.com/popper-lang/popper-lang",
-        "description": "Popper is an functional programming language designed to simplify the development process by providing a clear and concise syntax written in Rust",
-        "stars": 0,
-        "active": true
-    },
-    {
-        "name": "nu",
-        "url": "https://www.nushell.sh/book/nu_fundamentals.html",
-        "description": "Scripting language of [nushell](https://github.com/nushell/nushell). The goal of this project is to take the Unix philosophy of shells, where pipes connect simple commands together, and bring it to the modern style of development. Thus, rather than being either a shell, or a programming language, Nushell connects both by bringing a rich programming language and a full-featured shell together into one package.",
-        "stars": 25568,
+        "description": "The CLI that group all project to one to finally make the Popper-lang ",
+        "stars": 1,
         "active": true
     },
     {
         "name": "Roc",
         "url": "https://github.com/roc-lang/roc",
         "description": "A fast, friendly, functional language. Work in progress!",
-        "stars": 2263,
+        "stars": 3003,
         "active": true
     },
     {
         "name": "Move",
         "url": "https://github.com/move-language/move",
-        "description": "A programming language for writing safe and smart contracts in blockchain.",
-        "stars": 1989,
+        "description": null,
+        "stars": 2064,
         "active": true
     },
     {
@@ -792,50 +785,79 @@
     },
     {
         "name": "Stellar",
-        "url": "https://github.com/quantumatic/stellar"
+        "url": "https://github.com/quantumatic/stellar",
+        "description": "\u2728 An open source WIP general programming language for web development built using Rust. \u2728",
+        "stars": 40,
+        "active": true
     },
     {
         "name": "Oriel",
-        "url": "https://github.com/wojciech-graj/oriel"
+        "url": "https://github.com/wojciech-graj/oriel",
+        "description": "An interpreter for the 1991 Oriel scripting language",
+        "stars": 55,
+        "active": true
     },
     {
         "name": "Duckscript",
-        "url": "https://github.com/sagiegurari/duckscript"
+        "url": "https://github.com/sagiegurari/duckscript",
+        "description": "Simple, extendable and embeddable scripting language.",
+        "stars": 460,
+        "active": true
     },
     {
         "name": "Terbium",
-        "url": "https://github.com/terbium-lang/terbium"
+        "url": "https://github.com/terbium-lang/terbium",
+        "description": "A high-level language that doesn't compromise in performance, made with Rust.",
+        "stars": 19,
+        "active": true
     },
     {
         "name": "Loxcraft",
-        "url": "https://github.com/ajeetdsouza/loxcraft"
-    },
-    {
-        "name": "Tvix",
-        "url": "https://code.tvl.fyi/tree/tvix/eval"
+        "url": "https://github.com/ajeetdsouza/loxcraft",
+        "description": "Language tooling for the Lox programming language.",
+        "stars": 209,
+        "active": false
     },
     {
         "name": "Move",
-        "url": "https://github.com/move-language/move"
+        "url": "https://github.com/move-language/move",
+        "description": null,
+        "stars": 2064,
+        "active": true
     },
     {
         "name": "rusch",
-        "url": "https://github.com/twolodzko/rusch"
+        "url": "https://github.com/twolodzko/rusch",
+        "description": "Minimal Scheme implemented in Rust",
+        "stars": 1,
+        "active": true
     },
     {
         "name": "ClojureRS",
-        "url": "https://github.com/clojure-rs/ClojureRS"
+        "url": "https://github.com/clojure-rs/ClojureRS",
+        "description": "Clojure, implemented atop Rust (unofficial)",
+        "stars": 922,
+        "active": false
     },
     {
         "name": "diatom",
-        "url": "https://github.com/diatom-lang/diatom"
+        "url": "https://github.com/diatom-lang/diatom",
+        "description": "The diatom programming language",
+        "stars": 72,
+        "active": false
     },
     {
         "name": "darklua",
-        "url": "https://github.com/seaofvoices/darklua"
+        "url": "https://github.com/seaofvoices/darklua",
+        "description": "A command line tool that transforms Lua code",
+        "stars": 36,
+        "active": true
     },
     {
         "name": "Tvix",
-        "url": "https://github.com/tvlfyi/tvix"
+        "url": "https://github.com/tvlfyi/tvix",
+        "description": "Tvix - A Rust implementation of Nix. Read-only mirror of https://cs.tvl.fyi/depot/-/tree/tvix",
+        "stars": 186,
+        "active": true
     }
 ]

--- a/update.py
+++ b/update.py
@@ -99,8 +99,6 @@ def extract_languages():
 def api_request(token):
     """
     Update `languages.json` based on the latest API data for each language.
-
-    Note that this only updates the 'activity' and 'stars' values.
     """
 
     with open("languages.json", "r+", encoding="utf-8") as file:


### PR DESCRIPTION
I setup just to add Typst to the list, but in trying to run the README generator lots of data was getting clobbered. It seems the README got manually updated with a bunch of new projects without the JSON data even being added. I manually added all the missing projects (including finding current GitHub URLs for two that didn't have valid URLs at all) so that I could run the API data fetch and get everything sorted and re-written.
