### PR TITLE
Remove Parcel CSS

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -560,13 +560,6 @@
         "active": false
     },
     {
-        "name": "Parcel CSS",
-        "url": "https://github.com/parcel-bundler/parcel-css",
-        "description": "An extremely fast CSS parser, transformer, bundler, and minifier written in Rust.",
-        "stars": 6751,
-        "active": true
-    },
-    {
         "name": "Scryer Prolog",
         "url": "https://github.com/mthom/scryer-prolog",
         "description": "A modern Prolog implementation written mostly in Rust.",


### PR DESCRIPTION
"Parcel CSS" is now known as LightningCSS, which is also on the list of languages. You can see that https://github.com/parcel-bundler/parcel-css (the URL for Parcel CSS) redirects to https://github.com/parcel-bundler/lightningcss (the URL for LightningCSS). (This is also why the star counts and descriptions for the "two" projects are identical.) Therefore, Parcel CSS is a duplicate.